### PR TITLE
Remove Codecov upload step from CI workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,55 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install -r requirements.txt
+        pip install pytest pytest-cov pytest-asyncio
+    
+    - name: Run tests with coverage
+      env:
+        PYTHONPATH: ${{ github.workspace }}
+      run: |
+        python -m pytest tests/ -v --cov=app --cov-report=xml
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install linters
+      run: |
+        pip install black flake8 mypy isort
+    - name: Run black
+      run: black --check .
+    - name: Run flake8
+      run: flake8 .
+    - name: Run mypy
+      run: mypy .
+    - name: Run isort
+      run: isort --check-only .


### PR DESCRIPTION
## Changes
- Removed the Codecov upload step from the CI workflow
- Kept test coverage generation

## Why
This resolves the warning about the invalid CODECOV_TOKEN secret while maintaining test coverage functionality.